### PR TITLE
feat: support for content-reference fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.idea
 
 /dist
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "version:major": "standard-version --release-as major",
     "reset": "git clean -dfx && git reset --hard && npm i",
     "all": "run-s reset build test",
+    "prepare": "run-s clean build-ts build-copy-img",
     "prepare-patch-release": "run-s all version:patch",
     "prepare-minor-release": "run-s all version:minor",
     "prepare-major-release": "run-s all version:major"

--- a/src/EditorContentLinkField/EditorContentLinkField.tsx
+++ b/src/EditorContentLinkField/EditorContentLinkField.tsx
@@ -1,12 +1,6 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 
-import {
-  SvgIcon,
-  Tooltip,
-  Typography,
-  withStyles,
-  WithStyles
-} from "@material-ui/core";
+import { Tooltip, withStyles, WithStyles } from "@material-ui/core";
 import { KeyboardArrowDown, KeyboardArrowRight } from "@material-ui/icons";
 import clsx from "clsx";
 import CardContainer from "../Chooser/Chooser";
@@ -27,7 +21,7 @@ import Visualization from "../Visualization";
 
 import { ContentClient } from "dc-delivery-sdk-js";
 
-const styles = {
+export const styles = {
   root: {
     width: "100%"
   },
@@ -41,7 +35,9 @@ const styles = {
 };
 
 export interface EditorContentLinkFieldProps
-  extends WithEditorFieldProps<WithStyles<typeof styles>> {}
+  extends WithEditorFieldProps<WithStyles<typeof styles>> {
+  contentReference?: boolean;
+}
 
 function getContentTypes(schema: any): string[] {
   if (!schema.allOf) {
@@ -66,7 +62,7 @@ function getContentTypes(schema: any): string[] {
   return result;
 }
 
-const EditorContentLinkField: React.SFC<EditorContentLinkFieldProps> = (
+export const EditorContentLinkField: React.SFC<EditorContentLinkFieldProps> = (
   props: EditorContentLinkFieldProps
 ) => {
   const { schema, onChange, value, parentType, classes } = props;
@@ -79,9 +75,11 @@ const EditorContentLinkField: React.SFC<EditorContentLinkFieldProps> = (
   const handleBrowse = React.useCallback(async () => {
     try {
       if (sdk) {
-        const contentLink = await sdk.contentLink.get(contentTypes);
-        if (contentLink && onChange) {
-          onChange(contentLink);
+        const content = props.contentReference
+          ? await sdk.contentReference.get(contentTypes)
+          : await sdk.contentLink.get(contentTypes);
+        if (content && onChange) {
+          onChange(content);
         }
       }
       // tslint:disable-next-line

--- a/src/EditorContentReferenceField/EditorContentReferenceField.stories.tsx
+++ b/src/EditorContentReferenceField/EditorContentReferenceField.stories.tsx
@@ -3,13 +3,14 @@ import { SDK } from "dc-extensions-sdk";
 import React from "react";
 import SdkContext from "../SdkContext";
 import { withEditor } from "../utils/withEditor";
-import EditorContentLinkField from "./EditorContentLinkField";
+import "./EditorContentReferenceField";
 
 const schema = {
   type: "object",
   allOf: [
     {
-      $ref: "http://bigcontent.io/cms/schema/v1/core#/definitions/content-link"
+      $ref:
+        "http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference"
     },
     {
       properties: {
@@ -37,24 +38,25 @@ const schema = {
   }
 };
 
-const contentLink = {
+const contentReference = {
   _meta: {
-    schema: "http://bigcontent.io/cms/schema/v1/core#/definitions/content-link"
+    schema:
+      "http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference"
   },
   contentType:
     "https://raw.githubusercontent.com/neilmistryamplience/dc-example-website/willow/content-types/card.json",
-  id: "c6f77ffc-9d70-45e9-b322-89d4436b8774"
+  id: "f00c6599-29d1-4883-9fbc-3d3e9272c187"
 };
 
 const mockSdk = new SDK();
 mockSdk.field = { schema } as any;
 mockSdk.stagingEnvironment = "8d0nfe8p86q314k885enoody0.staging.bigcontent.io";
-mockSdk.contentLink.get = () => {
-  return Promise.resolve(contentLink);
+mockSdk.contentReference.get = () => {
+  return Promise.resolve(contentReference);
 };
 
-storiesOf("EditorContentLinkField", module).add("Editor", () => (
+storiesOf("EditorContentReferenceField", module).add("Editor", () => (
   <SdkContext.Provider value={{ sdk: mockSdk }}>
-    {withEditor(schema, contentLink)}
+    {withEditor(schema, contentReference)}
   </SdkContext.Provider>
 ));

--- a/src/EditorContentReferenceField/EditorContentReferenceField.tsx
+++ b/src/EditorContentReferenceField/EditorContentReferenceField.tsx
@@ -1,0 +1,10 @@
+import { withStyles } from "@material-ui/core";
+import {
+  EditorContentLinkField,
+  styles
+} from "../EditorContentLinkField/EditorContentLinkField";
+
+export default withStyles(styles, {
+  name: "DcEditorContentReferenceField",
+  contentReference: true
+})(EditorContentLinkField);

--- a/src/EditorContentReferenceField/index.ts
+++ b/src/EditorContentReferenceField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditorContentReferenceField";

--- a/src/EditorRegistry/EditorRegistry.ts
+++ b/src/EditorRegistry/EditorRegistry.ts
@@ -4,6 +4,7 @@ import { EditorFieldProps } from "../EditorField";
 import { ErrorReport, SchemaValidationError } from "dc-extensions-sdk";
 
 import EditorContentLinkField from "../EditorContentLinkField";
+import EditorContentReferenceField from "../EditorContentReferenceField";
 import EditorDropdownField from "../EditorDropdownField";
 import EditorMediaLinkField from "../EditorMediaLinkField";
 import EditorObjectField from "../EditorObjectField/EditorObjectField";
@@ -116,6 +117,12 @@ export function getDefaultRegistry(): EditorRegistry {
       forBuiltInSchema(
         ["http://bigcontent.io/cms/schema/v1/core#/definitions/content-link"],
         EditorContentLinkField
+      ),
+
+      // content-reference
+      forBuiltInSchema(
+        ["http://bigcontent.io/cms/schema/v1/core#/definitions/content-reference"],
+        EditorContentReferenceField
       ),
 
       // object

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,9 @@ export * from "./EditorMediaLinkField";
 export { default as EditorFieldContentLink } from "./EditorContentLinkField";
 export * from "./EditorContentLinkField";
 
+export { default as EditorFieldContentReference } from "./EditorContentReferenceField";
+export * from "./EditorContentReferenceField";
+
 export { default as EditorOneOfField } from "./EditorOneOfField";
 export * from "./EditorOneOfField";
 


### PR DESCRIPTION
- Add ability to use content-reference fields in a form.

- Make content-link component reusable for content-reference and clean-up it.

- Add prepare script to test content-reference feature (remove before release).